### PR TITLE
fixed redundant / inappropriate constraints regarding PK implicit con…

### DIFF
--- a/BRTBuildAndPopulate/BRT_Database_Build.sql
+++ b/BRTBuildAndPopulate/BRT_Database_Build.sql
@@ -37,75 +37,93 @@ CREATE TABLE brt_customer (
 );
 
 
+
 CREATE TABLE brt_order (
-    order_id NUMBER UNIQUE,
+    order_id NUMBER PRIMARY KEY,
     customer_id NUMBER UNIQUE,
     order_date DATE NOT NULL,
     estimated_delivery_date DATE NOT NULL,
     shipping_amount NUMBER(12,2) NOT NULL,
     tax_amount NUMBER(12,2) NOT NULL,
     shipping_province CHAR(2) NOT NULL,
-    FOREIGN KEY (customer_id) REFERENCES brt_customer(customer_id)
+    FOREIGN KEY (customer_id) 
+        REFERENCES brt_customer(customer_id)
+            ON DELETE CASCADE
 );
+
 
 CREATE TABLE brt_category (
   category_id NUMBER PRIMARY KEY,
   category_name VARCHAR2(50) NOT NULL
+  category_subname VARCHAR2(50) 
 );
 
 CREATE TABLE brt_product (
   product_id NUMBER PRIMARY KEY,
-  order_id NUMBER UNIQUE,
   title VARCHAR2(150) NOT NULL,
   description CLOB,
   price NUMBER(12,2) NOT NULL,
   weight_kg NUMBER(12,2) NOT NULL,
   is_tax_exempt NUMBER(1) NOT NULL,
-  category_id NUMBER(1) NOT NULL,
-  FOREIGN KEY (order_id) REFERENCES brt_order(order_id),
-  FOREIGN KEY (category_id) REFERENCES brt_category(category_id),
+  category_id NUMBER NOT NULL,
+  FOREIGN KEY (category_id) 
+    REFERENCES brt_category(category_id)
+        ON DELETE CASCADE,
   CONSTRAINT brt_product_CHK1 CHECK (price>0),
   CONSTRAINT brt_product_CHK2 CHECK (weight_kg>0),
   CONSTRAINT brt_product_CHK3 CHECK(is_tax_exempt IN (0,1))
 );
 
+
 --BRIDGING TABLES
 CREATE TABLE brt_product_suppliers (
-  product_id NUMBER NOT NULL UNIQUE,
-  supplier_id NUMBER NOT NULL UNIQUE,
+  product_id NUMBER NOT NULL,
+  supplier_id NUMBER NOT NULL,
   quantity_on_hand NUMBER NOT NULL,
-  estimated_delivery_days NUMBER NOT NULL,
-  PRIMARY KEY (product_id, supplier_id),
-  FOREIGN KEY (product_id) REFERENCES brt_product(product_id),
-  FOREIGN KEY (supplier_id) REFERENCES brt_supplier(supplier_id),
+  estimated_delivery_days NUMBER NOT NULL,  
+  FOREIGN KEY (product_id) 
+    REFERENCES brt_product(product_id)
+        ON DELETE CASCADE,
+  FOREIGN KEY (supplier_id) 
+    REFERENCES brt_suppliers(supplier_id)
+        ON DELETE CASCADE,
   CONSTRAINT quantity_on_hand_ck CHECK (quantity_on_hand>=0),
-  CONSTRAINT estimated_delivery_days_ck CHECK (estimated_delivery_days>=0)
+  CONSTRAINT estimated_delivery_days_ck CHECK (estimated_delivery_days>=0),
+  PRIMARY KEY (product_id, supplier_id)
 );
 
+
 CREATE TABLE brt_product_order (
-  order_id NUMBER NOT NULL,
-  product_id NUMBER NOT NULL,
-  product_amount NUMBER(10) NOT NULL, --greater than 0 
+  order_id NUMBER,
+  product_id NUMBER,
+  product_amount NUMBER(10) NOT NULL, --greater than 0   
+  FOREIGN KEY (order_id) 
+    REFERENCES brt_order(order_id)
+        ON DELETE CASCADE,
+  FOREIGN KEY (product_id)
+    REFERENCES brt_product(product_id)
+        ON DELETE CASCADE,
   CONSTRAINT order_product_pk PRIMARY KEY (order_id, product_id),
-  FOREIGN KEY (order_id) REFERENCES brt_order(order_id),
-  FOREIGN KEY (product_id) REFERENCES brt_product(product_id),
   CONSTRAINT product_amount_CHK1 CHECK (product_amount > 0)
 );
 
 CREATE TABLE brt_customer_review (
   review_id NUMBER PRIMARY KEY,
-  product_id NUMBER NOT NULL UNIQUE,
+  product_id NUMBER,
   rating NUMBER NOT NULL,
   comments CLOB,
   weight_kg NUMBER(12,2),
   is_tax_exempt NUMBER(1) NOT NULL,
   review_date DATE NOT NULL,
   price NUMBER(12,2),
-  FOREIGN KEY (product_id) REFERENCES brt_product(product_id),
+  FOREIGN KEY (product_id) 
+    REFERENCES brt_product(product_id)
+        ON DELETE CASCADE,
   CONSTRAINT rating_ck CHECK (rating BETWEEN 1 AND 5),
   CONSTRAINT price CHECK (price>0),
   CONSTRAINT weight_kg CHECK (weight_kg>0),
   CONSTRAINT is_tax_exempt CHECK (is_tax_exempt IN (0,1))
 );
+
 
 spool off 


### PR DESCRIPTION
Fixed

incorrect foreign key constraint on brt_product.order_id; order_id doesn't belong in brt_product because the brt_product_order bridging table is where the product-to-order association is established

missing primary key constraint on brt_order

the unique constraints specified are either:

redundant because the PK ensures the same uniqueness or
inappropriate and will put excessive restriction on your data